### PR TITLE
♻️ Begin refactoring main types out of lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //! At this time, the `outcome` crate is already taken on [crates.io]. As
 //! [crates.io] does not yet support namespaces or collections, we've had to
 //! take a *unique* approach to still publish the crate. To do this, we've
-//! generated a UUIDv5 string via python:
+//! generated a `UUIDv5` string via python:
 //!
 //! ```python
 //! from uuid import *

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,9 +24,84 @@
 //! forgetting to set a specific flag before calling a function), or busy
 //! resources (e.g., attempting to lock an audio, video, or database resource).
 //!
+//! ```
+//! # use outcome::*;
+//! # use std::error::Error;
+//! #[derive(Debug, PartialEq)]
+//! enum Version { V1, V2 }
+//!
+//! #[derive(Debug, PartialEq)]
+//! struct EmptyInput;
+//!
+//! fn parse_version(header: &[u8]) -> Outcome<Version, EmptyInput, &'static str> {
+//!   match header.get(0) {
+//!     None => Mistake(EmptyInput),
+//!     Some(&1) => Success(Version::V1),
+//!     Some(&2) => Success(Version::V2),
+//!     Some(_) => Failure("invalid or unknown version"),
+//!   }
+//! }
+//!
+//! let version = parse_version(&[]);
+//! assert_eq!(version, Mistake(EmptyInput));
+//! ```
+//!
+//! # Usage
+//!
+//! At this time, the `outcome` crate is already taken on [crates.io]. As
+//! [crates.io] does not yet support namespaces or collections, we've had to
+//! take a *unique* approach to still publish the crate. To do this, we've
+//! generated a UUIDv5 string via python:
+//!
+//! ```python
+//! from uuid import *
+//! print(uuid5(uuid5(NAMESPACE_DNS, "occult.work"), "outcome"))
+//! ```
+//!
+//! This *should* generate the string `46f94afc-026f-5511-9d7e-7d1fd495fb5c`.
+//! Thus the dependency in your `Cargo.toml` will look something like:
+//!
+//! ```toml
+//! [dependencies]
+//! outcome-46f94afc-026f-5511-9d7e-7d1fd495fb5c = "*"
+//! ```
+//!
+//! Is this solution friendly to users? No, but neither is the lack of
+//! namespacing or a squatting policy on [crates.io]. If/when this problem is
+//! resolved, this crate's documentation (and name!) will be changed and all
+//! versions will be yanked.
+//!
+//! # Features
+//!
+//! There are several features available to the crate that are disabled by
+//! default. These include:
+//!
+//!  - `unstable` (Enable "unstable" functions that mirror unstable functions
+//!      found in [`Result`]. Unlike [`Result`], however, a nightly compiler is
+//!      not required.)
+//!  - `nightly` (Enable features that require the nightly rust compiler to be
+//!      used, such as [`TryV2`])
+//!  - `report` (Enable conversion from [`Aberration`] to an
+//!      [`eyre::Report`])
+//!
+//! Users can also enable `no_std` support by either setting `default-features`
+//! to `false` or simply not listing `std` in the list of features.
+//!
+//!  - `nightly` will enable `unstable`.
+//!  - `report` will enable `std`.
+//!
 //! # `no_std` support
 //!
-//! // TODO: ...
+//! Nearly every single feature in `outcome` supports working with `#![no_std]`
+//! support, however currently `eyre` *does* require `std` support (Attempts
+//! were made at making `no_std` work, but this was removed and has not been
+//! available for some time).
+//!
+//!
+//! ```toml
+//! [dependencies]
+//! outcome-46f94afc-026f-5511-9d7e-7d1fd495fb5c = { version = "...", features = ["nightly"] }
+//! ```
 //!
 //! # Why Augment `Result<T, E>`?
 //!
@@ -36,7 +111,7 @@
 //! provides the ability to quickly expand the surface area of consumed APIs
 //! with finer grained control over errors so that library writers can write
 //! *correct* behavior and then return at a later time to compose results,
-//! expand error definitions, or  to represent different error severities.
+//! expand error definitions, or to represent different error severities.
 //!
 //! As an example, the section [making unhandled errors unrepresentable][1] in
 //! the post *Error Handling in a Correctness-Critical Rust Project*, the
@@ -116,57 +191,10 @@
 //! [`TryV2`]: core::ops::TryV2
 //! [`Try`]: core::ops::Try
 //!
+//! [crates.io]: https://crates.io
+//!
 //! [1]: https://sled.rs/errors.html#making-unhandled-errors-unrepresentable
 //! [2]: https://crates.io/crates/nom
-//!
-//! # XXX: The section below is to be rewritten. Ignore it for now.
-//!
-//! This statement above is *exactly* what [`Outcome`] is written to *help*
-//! prevent.
-//!
-//! As
-//! an example, [`UnixDatagram::take_error`] returns a type that, once expanded
-//! looks something like much like `Result<Option<Error>, Error>`. Internally,
-//! this is calling a series of internal functions that eventually call into
-//! afunction that is part of the C FFI. However, there are two error states
-//! here. The actual *possible* error that users will care about (the
-//! `Option<Error>`) and the `Error` that might be returned for a variety of
-//! other reasons.
-//!
-//! In other words,
-//! [`Outcome`] is *not* for the average Rust developer to use, but for
-//! internal use within the confines of a crate.
-//!
-//! The idea behind an `Outcome` is that error handling cannot usually signify
-//! to the client of an API that a function *should* be retried. In some Rust
-//! libraries, the use of a `Result<T, Result<U, E>>` is used in these places
-//! and it makes consuming these APIs cumbersome, unnecessarily difficult,
-//! and promotes use of the WTF operator (`??`).
-//!
-//! ```
-//! # use outcome::*;
-//! # use std::error::Error;
-//! #[derive(Debug)]
-//! enum Version { V1, V2 }
-//!
-//! struct EmptyInput;
-//!
-//! fn parse_version(header: &[u8]) -> Outcome<Version, EmptyInput, &'static str> {
-//!   match header.get(0) {
-//!     None => Mistake(EmptyInput),
-//!     Some(&1) => Success(Version::V1),
-//!     Some(&2) => Success(Version::V2),
-//!     Some(_) => Failure("invalid or unknown version"),
-//!   }
-//! }
-//!
-//! let _version = parse_version(&[]);
-//! ```
-//!
-//! In other cases, such as the one found with [`TryLockError<T>`], the
-//! non-recoverable error is [`PoisonError<T>`], while the *retryable* error
-//! returned is [`WouldBlock`], which *can* be tried again, possibly with a
-//! pattern known as exponential back-off.
 
 #![warn(clippy::cargo_common_metadata)]
 #![warn(clippy::default_numeric_fallback)]
@@ -215,6 +243,7 @@ mod nightly;
 
 mod convert;
 mod iter;
+mod stable;
 
 /// `Outcome` is a type that can represet a [`Success`], [`Mistake`], or [`Failure`].
 ///
@@ -230,36 +259,11 @@ pub enum Outcome<S, M, F> {
   Failure(F),
 }
 
-/// `Aberration` is a type that can represet a [`Mistake`], or [`Failure`].
-///
-/// See the [module documentation](self) for details.
-#[must_use = "This Aberration might be a `Mistake`, which should be handled"]
-pub enum Aberration<M, F> {
-  /// Contains the mistake value
-  Mistake(M),
-  /// Contains the failure value
-  Failure(F),
-}
-
-/// (WIP Name) `Concern` is a type that can represent a [`Success`], or
-/// [`Mistake`].
-///
-/// This type is *currently* planned to be used for the unstable [`TryV2`]
-/// trait.
-///
-/// See the [module documentation](self) for details.
-///
-/// [`TryV2`]: core::ops::TryV2
-#[must_use = "This Concern might be a `Mistake`, which should be handled"]
-pub enum Concern<S, M> {
-  /// Contains the success value
-  Success(S),
-  /// Contains the mistake value
-  Mistake(M),
-}
-
 #[doc(inline)]
 pub use crate::{convert::*, iter::*};
+
+#[doc(inline)]
+pub use crate::stable::{Aberration, Concern};
 
 #[doc(hidden)]
 pub use Outcome::{Failure, Mistake, Success};

--- a/src/stable.rs
+++ b/src/stable.rs
@@ -1,0 +1,225 @@
+use crate::*;
+
+/// `Aberration` is a type that can represet a [`Mistake`], or [`Failure`].
+///
+/// See the [module documentation](crate) for details.
+#[must_use = "This Aberration might be a `Mistake`, which should be handled"]
+pub enum Aberration<M, F> {
+  /// Contains the mistake value
+  Mistake(M),
+  /// Contains the failure value
+  Failure(F),
+}
+
+/// (WIP Name) `Concern` is a type that can represent a [`Success`], or
+/// [`Mistake`].
+///
+/// This type is *currently* planned to be used for the unstable [`TryV2`]
+/// trait.
+///
+/// See the [module documentation](crate) for details.
+///
+/// [`TryV2`]: core::ops::TryV2
+#[must_use = "This Concern might be a `Mistake`, which should be handled"]
+pub enum Concern<S, M> {
+  /// Contains the success value
+  Success(S),
+  /// Contains the mistake value
+  Mistake(M),
+}
+
+impl<M, F> Aberration<M, F> {
+  /// Converts from `&Aberration<M, F>` to `Aberration<&M, &F>`.
+  ///
+  /// Produces a new `Aberration`, containing a reference into the original,
+  /// leaving it in place.
+  #[inline]
+  pub fn as_ref(&self) -> Aberration<&M, &F> {
+    match *self {
+      Self::Mistake(ref value) => Aberration::Mistake(value),
+      Self::Failure(ref value) => Aberration::Failure(value),
+    }
+  }
+
+  /// Converts from `&mut Aberration<M, F>` to `Aberration<&mut M, &mut F>`
+  #[inline]
+  pub fn as_mut(&mut self) -> Aberration<&mut M, &mut F> {
+    match *self {
+      Self::Mistake(ref mut value) => Aberration::Mistake(value),
+      Self::Failure(ref mut value) => Aberration::Failure(value),
+    }
+  }
+
+  /// Returns `true` if the aberration is a [`Mistake`]
+  ///
+  /// [`Mistake`]: Aberration::Mistake
+  #[must_use = "if you intended to assert a mistake, consider `.unwrap_mistake()` instead"]
+  #[inline]
+  pub fn is_mistake(&self) -> bool {
+    if let Self::Mistake(_) = self {
+      return true;
+    }
+    false
+  }
+
+  /// Returns `true` if the aberration is a [`Failure`]
+  ///
+  /// [`Failure`]: Aberration::Failure
+  #[must_use = "if you intended to assert a failure, consider `.unwrap_failure()` instead"]
+  #[inline]
+  pub fn is_failure(&self) -> bool {
+    if let Self::Failure(_) = self {
+      return true;
+    }
+    false
+  }
+
+  /// Converts from `Aberration<M, F>` to [`Option<M>`]
+  #[inline]
+  pub fn mistake(self) -> Option<M> {
+    if let Self::Mistake(value) = self {
+      return Some(value);
+    }
+    None
+  }
+
+  /// Converts from `Aberration<M, F>` to [`Option<F>`]
+  #[inline]
+  pub fn failure(self) -> Option<F> {
+    if let Self::Failure(value) = self {
+      return Some(value);
+    }
+    None
+  }
+
+  /// Maps an `Aberration<M, F>` to `Aberration<N, F>` by applying a function
+  /// to a contained [`Mistake`] value, leaving any [`Failure`] value
+  /// untouched.
+  ///
+  /// [`Mistake`]: Aberration::Mistake
+  /// [`Failure`]: Aberration::Failure
+  #[inline]
+  pub fn map_mistake<N, C>(self, callable: C) -> Aberration<N, F>
+  where
+    C: FnOnce(M) -> N,
+  {
+    match self {
+      Self::Mistake(value) => Aberration::Mistake(callable(value)),
+      Self::Failure(value) => Aberration::Failure(value),
+    }
+  }
+
+  /// Maps an `Aberration<M, F>` to `Aberration<M, G>` by applying a function
+  /// to a contained [`Failure`] value, leaving any [`Mistake`] value
+  /// untouched.
+  ///
+  /// [`Mistake`]: Aberration::Mistake
+  /// [`Failure`]: Aberration::Failure
+  #[inline]
+  pub fn map_failure<G, C>(self, callable: C) -> Aberration<M, G>
+  where
+    C: FnOnce(F) -> G,
+  {
+    match self {
+      Self::Mistake(value) => Aberration::Mistake(value),
+      Self::Failure(value) => Aberration::Failure(callable(value)),
+    }
+  }
+}
+
+impl<M, F: Debug> Aberration<M, F> {
+  /// Returns the contained [`Mistake`] value, consuming the `self` value.
+  ///
+  /// # Panics
+  ///
+  /// Panics if the value is a [`Failure`], with a custom panic message
+  /// provided by the failure.
+  ///
+  /// # Examples
+  ///
+  /// ```should_panic
+  /// # use outcome::*;
+  /// let x: Aberration<&str, i32> = Aberration::Failure(47);
+  /// x.unwrap_mistake(); // panics with '47'
+  /// ```
+  ///
+  /// ```
+  /// # use outcome::*;
+  /// let x: Aberration<&str, i32> = Aberration::Mistake("try again!");
+  /// assert_eq!(x.unwrap_mistake(), "try again!");
+  /// ```
+  ///
+  /// [`Mistake`]: Aberration::Mistake
+  /// [`Failure`]: Aberration::Failure
+  #[track_caller]
+  #[inline]
+  pub fn unwrap_mistake(self) -> M {
+    match self {
+      Self::Mistake(m) => m,
+      Self::Failure(f) => {
+        panic!(
+          "Called `Aberration::unwrap_mistake()` on a `Failure` value: {:?}",
+          f
+        );
+      }
+    }
+  }
+}
+
+impl<M: Debug, F> Aberration<M, F> {
+  /// Returns the contained [`Failure`] value, consuming the `self` value.
+  ///
+  /// # Panics
+  ///
+  /// Panics if the value is a [`Mistake`], with a custom panic message
+  /// provided by the mistake.
+  ///
+  /// # Examples
+  ///
+  /// ```should_panic
+  /// # use outcome::*;
+  /// let x: Aberration<i32, &str> = Aberration::Mistake(47);
+  /// x.unwrap_failure(); // panics with '47'
+  /// ```
+  ///
+  /// ```
+  /// # use outcome::*;
+  /// let x: Aberration<i32, &str> = Aberration::Failure("error!");
+  /// assert_eq!(x.unwrap_failure(), "error!");
+  /// ```
+  ///
+  /// [`Mistake`]: Aberration::Mistake
+  /// [`Failure`]: Aberration::Failure
+  #[track_caller]
+  #[inline]
+  pub fn unwrap_failure(self) -> F {
+    match self {
+      Self::Mistake(m) => {
+        panic!(
+          "Called `Aberration::unwrap_failure()` on a `Mistake` value: {:?}",
+          m
+        );
+      }
+      Self::Failure(f) => f,
+    }
+  }
+}
+
+impl<M: Clone, F: Clone> Clone for Aberration<M, F> {
+  #[inline]
+  fn clone(&self) -> Self {
+    match self {
+      Self::Mistake(value) => Self::Mistake(value.clone()),
+      Self::Failure(value) => Self::Failure(value.clone()),
+    }
+  }
+
+  #[inline]
+  fn clone_from(&mut self, source: &Self) {
+    match (self, source) {
+      (Self::Mistake(to), Self::Mistake(from)) => to.clone_from(from),
+      (Self::Failure(to), Self::Failure(from)) => to.clone_from(from),
+      (to, from) => *to = from.clone(),
+    }
+  }
+}


### PR DESCRIPTION
✨ Add basic `impl` for `Aberration<M, F>`
📝 Cleanup module documentation

The amount of documentation in the main library file makes it hard to
navigate the source code itself.

At the moment we're moving the Aberration and Concern types into a
submodule named 'stable', however we'll most likely separate each one
into their own file and then place either nightly or unstable features
in each respective source file.

The layout of this project is atypical, but this project itself is
atypical so I can't say I'm surprised to be honest. 😅
