### PR TITLE
♻️ Refactor crate::report::*;

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/.cargo
 /target
 Cargo.lock

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,8 +114,10 @@
 //!
 //!
 //! ```toml
-//! [dependencies]
-//! outcome-46f94afc-026f-5511-9d7e-7d1fd495fb5c = { version = "...", features = ["nightly"] }
+//! [dependencies.outcome]
+//! package = "outcome-46f94afc-026f-5511-9d7e-7d1fd495fb5c"
+//! version = "..."
+//! features = ["nightly"]
 //! ```
 //!
 //! ### `unstable`
@@ -149,6 +151,14 @@
 //!    - In addition to being usable with `fn main()`, *any unit test* may
 //!        return an [`Outcome`] directly. This works in the same way as
 //!        returning a [`Result<T, E>`]
+//!
+//! ### `report`
+//!
+//! The `report` feature adds several additional associated methods to beoth
+//! [`Outcome`] and [`Aberration`]. These are meant to mimic the [`WrapErr`]
+//! functions found on [`Result<T, E>`] that is provided by [`eyre`]. However,
+//! to stay in line with `outcome`'s naming convention, instances of `err` have
+//! been replaced with `failure`.
 //!
 //! # Why Augment `Result<T, E>`?
 //!
@@ -224,18 +234,23 @@
 //!
 //! # State Escalation (TODO)
 //!
-//! [`Success(S)`]: crate::prelude::Success
-//! [`Mistake(M)`]: crate::prelude::Mistake
-//! [`Failure(F)`]: crate::prelude::Failure
+//! ---
+//!
+//! [`Try`]: core::ops::Try
 //!
 //! [`TryLockError<T>`]: std::sync::TryLockError
 //! [`PoisonError<T>`]: std::sync::PoisonError
 //! [`WouldBlock`]: std::sync::TryLockError::WouldBlock
 //!
-//! [`UnixDatagram::take_error`]: https://doc.rust-lang.org/nightly/std/os/unix/net/struct.UnixDatagram.html#method.take_error
-//! [`Try`]: core::ops::Try
+//! [`WrapErr`]: eyre::WrapErr
 //!
+//! [`Success(S)`]: crate::prelude::Success
+//! [`Mistake(M)`]: crate::prelude::Mistake
+//! [`Failure(F)`]: crate::prelude::Failure
+//!
+//! [`UnixDatagram::take_error`]: https://doc.rust-lang.org/nightly/std/os/unix/net/struct.UnixDatagram.html#method.take_error
 //! [crates.io]: https://crates.io
+//! [`eyre`]: https://crates.io/crates/eyre
 //!
 //! [1]: https://sled.rs/errors.html#making-unhandled-errors-unrepresentable
 //! [2]: https://crates.io/crates/nom
@@ -280,10 +295,6 @@
 #[cfg(doc)]
 extern crate std;
 
-#[cfg_attr(any(docsrs, nightly), doc(cfg(feature = "report")))]
-#[cfg(feature = "report")]
-mod report;
-
 #[cfg_attr(any(docsrs, nightly), doc(cfg(feature = "unstable")))]
 #[cfg(feature = "unstable")]
 mod unstable;
@@ -301,6 +312,10 @@ mod iter;
 
 pub mod convert;
 pub mod prelude;
+
+#[cfg_attr(any(docsrs, nightly), doc(cfg(feature = "report")))]
+#[cfg(feature = "report")]
+pub mod report;
 
 #[cfg_attr(doc, doc(inline))]
 pub use crate::{aberration::*, concern::*, convert::*, iter::*, outcome::*};

--- a/src/private.rs
+++ b/src/private.rs
@@ -10,3 +10,12 @@ use core::fmt::Debug;
 pub fn panic(method: &str, variant: &str, error: &dyn Debug) -> ! {
   panic!("Called `{}` on a `{}` value: {:?}", method, variant, error);
 }
+
+pub trait Sealed {}
+
+#[cfg(feature = "report")]
+impl<T, E> Sealed for Result<T, E> where E: Into<eyre::Report> {}
+
+impl<S, M, F> Sealed for crate::outcome::Outcome<S, M, F> {}
+impl<M, F> Sealed for crate::aberration::Aberration<M, F> {}
+impl<S, M> Sealed for crate::concern::Concern<S, M> {}

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,27 +1,101 @@
+//! Support for the [`eyre`] crate
+//!
+//! [`eyre`]: https://crates.io/crates/eyre
 extern crate std;
 
 use std::{error::Error, fmt::Display};
 
-use eyre::Report;
+pub use eyre::Report;
 
 use crate::prelude::*;
 
-/// Provides easier interop with [`Report`].
+/// Provides the `wrap_failure` method for [`Outcome`].
 ///
-/// Each associated method is meant to match the equivalent set of calls found
-/// in [`WrapErr`], but with `outcome`'s naming convention, where instances of
-/// `err` are replaced with `failure`.
+/// This trait is sealed and cannot be implemented for types outside of
+/// `outcome`.
 ///
+/// Additionally, this trait is meant to *mirror* the [`WrapErr`] trait found
+/// in [`eyre`].
+///
+/// [`Outcome`]: crate::prelude::Outcome
 /// [`WrapErr`]: eyre::WrapErr
-/// [`Report`]: eyre::Report
-impl<S, M, E> Outcome<S, M, E>
+///
+/// [`eyre`]: https://crates.io/crates/eyre
+#[cfg(feature = "report")]
+pub trait WrapFailure: Sized + crate::private::Sealed {
+  /// The expected return type for an `impl`.
+  ///
+  /// This will always be the same enumeration type, but with a [`Report`]
+  /// in the error or failure position.
+  type Return;
+
+  /// Wrap the failure value with a new adhoc error.
+  fn wrap_failure_with<D, F>(self, message: F) -> Self::Return
+  where
+    D: Display + Send + Sync + 'static,
+    F: FnOnce() -> D;
+
+  /// Wrap the failure value with a new adhoc error that is evaluated lazily
+  /// only once an error does occur.
+  fn wrap_failure<D>(self, message: D) -> Self::Return
+  where
+    D: Display + Send + Sync + 'static;
+
+  /// Compatibility re-export of [`wrap_failure_with`] for interop with
+  /// [`anyhow`] and [`eyre`].
+  ///
+  /// [`wrap_failure_with`]: WrapFailure::wrap_failure_with
+  /// [`anyhow`]: https://crates.io/crates/anyhow
+  /// [`eyre`]: https://crates.io/crates/eyre
+  #[track_caller]
+  #[inline]
+  fn with_context<D, F>(self, message: F) -> Self::Return
+  where
+    D: Display + Send + Sync + 'static,
+    F: FnOnce() -> D,
+  {
+    self.wrap_failure_with(message)
+  }
+
+  /// Compatibility re-export of [`wrap_failure`] for interop with
+  /// [`anyhow`] and [`eyre`].
+  ///
+  /// [`wrap_failure`]: WrapFailure::wrap_failure
+  /// [`anyhow`]: https://crates.io/crates/anyhow
+  /// [`eyre`]: https://crates.io/crates/eyre
+  #[track_caller]
+  #[inline]
+  fn context<D>(self, message: D) -> Self::Return
+  where
+    D: Display + Send + Sync + 'static,
+  {
+    self.wrap_failure(message)
+  }
+}
+
+impl<S, M, E> WrapFailure for Outcome<S, M, E>
 where
   E: Error + Send + Sync + 'static,
 {
-  /// Wrap the failure value with a new adhoc error
+  type Return = Outcome<S, M, Report>;
+
   #[track_caller]
   #[inline]
-  pub fn wrap_failure<D>(self, message: D) -> Outcome<S, M, Report>
+  fn wrap_failure_with<D, F>(self, message: F) -> Self::Return
+  where
+    D: Display + Send + Sync + 'static,
+    F: FnOnce() -> D,
+  {
+    match self {
+      Success(s) => Success(s),
+      Mistake(m) => Mistake(m),
+      Failure(f) => Failure(Report::new(f).wrap_err(message())),
+    }
+  }
+
+  #[track_caller]
+  #[inline]
+  fn wrap_failure<D>(self, message: D) -> Self::Return
   where
     D: Display + Send + Sync + 'static,
   {
@@ -31,63 +105,32 @@ where
       Failure(f) => Failure(Report::new(f).wrap_err(message)),
     }
   }
+}
 
-  /// Wrap the failure value with a new adhoc error that is evaluated lazily only
-  /// once a failure does occur.
+impl<M, E> WrapFailure for Aberration<M, E>
+where
+  E: Error + Send + Sync + 'static,
+{
+  type Return = Aberration<M, Report>;
+
   #[track_caller]
   #[inline]
-  pub fn wrap_failure_with<D, F>(self, function: F) -> Outcome<S, M, Report>
+  fn wrap_failure_with<D, F>(self, message: F) -> Self::Return
   where
     D: Display + Send + Sync + 'static,
     F: FnOnce() -> D,
   {
     match self {
-      Success(s) => Success(s),
-      Mistake(m) => Mistake(m),
-      Failure(f) => Failure(Report::new(f).wrap_err(function())),
+      Self::Mistake(m) => Aberration::Mistake(m),
+      Self::Failure(f) => {
+        Aberration::Failure(Report::new(f).wrap_err(message()))
+      }
     }
   }
 
-  /// Compatibility re-export of [`wrap_failure`] for interop with [`anyhow`]
-  /// and [`eyre`].
-  ///
-  /// [`wrap_failure`]: crate::prelude::Outcome::wrap_failure
-  /// [`anyhow`]: https://crates.io/crates/anyhow
-  /// [`eyre`]: https://crates.io/crates/eyre
   #[track_caller]
   #[inline]
-  pub fn context<D>(self, message: D) -> Outcome<S, M, Report>
-  where
-    D: Display + Send + Sync + 'static,
-  {
-    self.wrap_failure(message)
-  }
-
-  /// Compatibility re-export of [`wrap_failure_with`] for interop with
-  /// [`anyhow`] and [`eyre`].
-  ///
-  /// [`wrap_failure_with`]: crate::prelude::Outcome::wrap_failure_with
-  /// [`anyhow`]: https://crates.io/crates/anyhow
-  /// [`eyre`]: https://crates.io/crates/eyre
-  #[track_caller]
-  #[inline]
-  pub fn with_context<D, F>(self, function: F) -> Outcome<S, M, Report>
-  where
-    D: Display + Send + Sync + 'static,
-    F: FnOnce() -> D,
-  {
-    self.wrap_failure_with(function)
-  }
-}
-
-impl<M, E> Aberration<M, E>
-where
-  E: Error + Send + Sync + 'static,
-{
-  /// Wrap the error value with a new adhoc error
-  #[track_caller]
-  #[inline]
-  pub fn wrap_failure<D>(self, message: D) -> Aberration<M, Report>
+  fn wrap_failure<D>(self, message: D) -> Self::Return
   where
     D: Display + Send + Sync + 'static,
   {
@@ -96,49 +139,30 @@ where
       Self::Failure(f) => Aberration::Failure(Report::new(f).wrap_err(message)),
     }
   }
+}
 
-  /// Wrap the error value with a new adhoc error that is evaluated lazily only
-  /// once an error does occur.
+impl<T, E> WrapFailure for Result<T, E>
+where
+  E: Error + Send + Sync + 'static,
+{
+  type Return = Result<T, Report>;
+
   #[track_caller]
   #[inline]
-  pub fn wrap_failure_with<D, F>(self, function: F) -> Aberration<M, Report>
+  fn wrap_failure_with<D, F>(self, message: F) -> Self::Return
   where
     D: Display + Send + Sync + 'static,
     F: FnOnce() -> D,
   {
-    match self {
-      Self::Mistake(m) => Aberration::Mistake(m),
-      Self::Failure(f) => {
-        Aberration::Failure(Report::new(f).wrap_err(function()))
-      }
-    }
+    eyre::WrapErr::wrap_err_with(self, message)
   }
 
-  /// Compatibility re-export of [`wrap_failure`] for interopt with [`anyhow`].
-  ///
-  /// [`wrap_failure`]: crate::prelude::Outcome::wrap_failure
-  /// [`anyhow`]: https://crates.io/crates/anyhow
   #[track_caller]
   #[inline]
-  pub fn context<D>(self, message: D) -> Aberration<M, Report>
+  fn wrap_failure<D>(self, message: D) -> Self::Return
   where
     D: Display + Send + Sync + 'static,
   {
-    self.wrap_failure(message)
-  }
-
-  /// Compatibility re-export of [`wrap_failure_with`] for interopt with
-  /// [`anyhow`].
-  ///
-  /// [`wrap_failure_with`]: crate::prelude::Aberration::wrap_failure_with
-  /// [`anyhow`]: https://crates.io/crates/anyhow
-  #[track_caller]
-  #[inline]
-  pub fn with_context<D, F>(self, function: F) -> Aberration<M, Report>
-  where
-    D: Display + Send + Sync + 'static,
-    F: FnOnce() -> D,
-  {
-    self.wrap_failure_with(function)
+    eyre::WrapErr::wrap_err(self, message)
   }
 }


### PR DESCRIPTION
 - The module is now documented as existing
 - Re-export `eyre::Report`
 - Created an equivalent `WrapFailure` trait to mirror eyre::WrapErr

📝 We now document the `cfg(feature = "report")` setting.
✅ Add test to make sure things like Outcome::failure work with `filter_map`
