### PR TITLE
🐛 Fix WrapFailure implementation for Result<T, E>

### DIFF
--- a/src/private.rs
+++ b/src/private.rs
@@ -14,7 +14,7 @@ pub fn panic(method: &str, variant: &str, error: &dyn Debug) -> ! {
 pub trait Sealed {}
 
 #[cfg(feature = "report")]
-impl<T, E> Sealed for Result<T, E> where E: Into<eyre::Report> {}
+impl<T, E> Sealed for Result<T, E> {}
 
 impl<S, M, F> Sealed for crate::outcome::Outcome<S, M, F> {}
 impl<M, F> Sealed for crate::aberration::Aberration<M, F> {}


### PR DESCRIPTION
♻️ `WrapFailure` no longer required `Sized`
📝 `eyre::Report` and `Result` are now documented as re-exports
✅ Add doctest for wrap_failure as an example

This solves a small hole in our current API that appears to compile
correctly but cannot be used as intended.
