### PR TITLE
🐛 Fix nightly annotations by importing fmt::Debug when feature = std

### DIFF
--- a/src/nightly.rs
+++ b/src/nightly.rs
@@ -2,12 +2,12 @@
 extern crate std;
 use core::{
   convert::Infallible,
-  fmt::Debug,
   ops::{ControlFlow, FromResidual, Try},
 };
 #[cfg(feature = "std")]
 use std::{
   eprintln,
+  fmt::Debug,
   process::{ExitCode, Termination},
 };
 


### PR DESCRIPTION
This should cleanup a *bunch* of debug output from github CI that is technically correct.
