### PR TITLE
📝 Edit docs to render more correctly on GitHub *and* rustdoc

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -9,7 +9,7 @@ default. These include:
  - `nightly` (Enable features that require the nightly rust compiler to be
      used, such as [`Try`])
  - `report` (Enable conversion from [`Aberration`] to an
-     [`eyre::Report`])
+     [`eyre::Report`][`eyre::Report`])
 
 Users can also enable `no_std` support by either setting `default-features`
 to `false` or simply not listing `std` in the list of features.
@@ -34,9 +34,9 @@ features = ["nightly"]
 
 ### `unstable`
 
-When enabled, the `unstable` feature provides several associated methods
-for [`Outcome`] that mirror unstable APIs found in [`Result<T, E>`]. If the
-methods mirrored are changed in any future releases of stable rust, these
+When enabled, the `unstable` feature provides several associated methods for
+[`Outcome`] that mirror unstable APIs found in [`Result<T, E>`][`Result`]. If
+the methods mirrored are changed in any future releases of stable rust, these
 will as well. Additionally, if any of the APIs are stabilized, they will be
 moved out of this feature and into the default feature set. Unlike the
 `nightly` feature, these APIs can be implemented in *stable* rust.
@@ -70,10 +70,19 @@ each API set mentioned. These are listed below.
 
 The `report` feature adds the [`WrapFailure`] trait to both [`Outcome`] and
 [`Aberration`]. This trait is meant to mimic the [`WrapErr`] trait found on
-[`Result<T, E>`] that is provided by [`eyre`].  Therefore, a blanket
+[`Result<T, E>`][`Result`] that is provided by [`eyre`].  Therefore, a blanket
 implementation is provided for all types that implement [`WrapErr`].  However,
 to stay in line with `outcome`'s naming convention, instances of `err` have
 been replaced with `failure`.
 
-[`WrapFailure`]: crate::report::WrapFailure
+[`Result`]: core::result::Result
+[`Try`]: core::ops::Try
+
 [`WrapErr`]: eyre::WrapErr
+[`Report`]: eyre::Report
+
+[`WrapFailure`]: crate::report::WrapFailure
+[`Aberration`]: crate::prelude::Aberration
+[`Outcome`]: crate::prelude::Outcome
+
+[`eyre`]: https://crates.io/crates/eyre

--- a/docs/why-augment-result.md
+++ b/docs/why-augment-result.md
@@ -65,7 +65,7 @@ moderately complex pattern matching to extract relevant information.
 
 Luckily, it *is* easier to prevent this issue in the first place if:
 
- - An explicit call to extract an inner `Result<T, E>` must be made
+ - An explicit call to extract an inner `Result<T, E>`-like type must be made
  - The call of an easily greppable/searchable function before using the
     "WTF" (`??`) operator is permitted.
  - The [`Try`] trait returns a type that *must* be decomposed explicitly
@@ -75,7 +75,20 @@ Thanks to [clippy](https://github.com/rust-lang/rust-clippy)'s
 `disallowed_method` lint, users can rely on the first two options until
 [`Try`] has been stabilized.
 
+`outcome` provides this in the form of its [`Concern`] type, whose variants
+match the [`Success`] and [`Failure`] of [`Outcome`], as well as the associated
+function [`Outcome::acclimate`], which returns a `Result<Concern<S, M>, F>`.
+
+**NOTE**: This associated function will be deprecated once [`Try`] has been
+stabilized.
+
 [`Try`]: core::ops::Try
+
+[`Outcome::acclimate`]: crate::prelude::Outcome::acclimate
+[`Concern`]: crate::prelude::Concern
+[`Success`]: crate::prelude::Success
+[`Failure`]: crate::prelude::Failure
+[`Outcome`]: crate::prelude::Outcome
 
 [1]: https://sled.rs/errors.html#making-unhandled-errors-unrepresentable
 [2]: https://crates.io/crates/nom


### PR DESCRIPTION
We can now link folks to specific subdocuments as needed, and while the links to the actual types won't work, it won't look *awful* by comparison.    