### PR TITLE
🐛 Fix documentation intralinks

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -9,7 +9,7 @@ default. These include:
  - `nightly` (Enable features that require the nightly rust compiler to be
      used, such as [`Try`])
  - `report` (Enable conversion from [`Aberration`] to an
-     [`eyre::Report`][`eyre::Report`])
+     [`eyre::Report`][`Report`])
 
 Users can also enable `no_std` support by either setting `default-features`
 to `false` or simply not listing `std` in the list of features.

--- a/docs/why-augment-result.md
+++ b/docs/why-augment-result.md
@@ -82,6 +82,7 @@ function [`Outcome::acclimate`], which returns a `Result<Concern<S, M>, F>`.
 **NOTE**: This associated function will be deprecated once [`Try`] has been
 stabilized.
 
+[`Result`]: core::result::Result
 [`Try`]: core::ops::Try
 
 [`Outcome::acclimate`]: crate::prelude::Outcome::acclimate


### PR DESCRIPTION
This fixes some rustdoc warnings, as well as rendering on GitHub    