### PR TITLE
📝 Add initial documentation on state escalation API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "outcome-46f94afc-026f-5511-9d7e-7d1fd495fb5c"
-version = "0.0.0"
-edition = "2018"
 description = "Augmentations for error propagation"
 repository = "https://github.com/slurps-mad-rips/outcome"
+version = "0.0.0"
+edition = "2018"
 license = "MIT"
 readme = "README.md"
-keywords = ["outcome", "result", "failure", "eyre"]
 categories = ["no-std", "rust-patterns"]
-resolver = "2"
-include = ["src", "Cargo.toml", "LICENSE.md"]
+keywords = ["outcome", "result", "failure", "eyre"]
+include = ["docs", "src", "Cargo.toml", "LICENSE.md"]
 build = "build.rs"
+resolver = "2"
 
 [lib]
 name = "outcome"

--- a/docs/features.md
+++ b/docs/features.md
@@ -59,6 +59,8 @@ each API set mentioned. These are listed below.
  - `#![feature(never_type)]` &mdash; APIs that return `!`
    - [`Outcome`] will have several functions where the `!` type is used in
        the function signature. These include `into_success`, and others.
+   - Several stable functions that return an [`Aberration`] will instead return
+       an `Outcome<!, M, F>`.
  - `#![feature(termination_trait_lib)]` &mdash; Exit process with an
       [`Outcome`]
    - **NOTE**: This requires the `std` feature to be enabled as well.

--- a/docs/state-escalation.md
+++ b/docs/state-escalation.md
@@ -1,3 +1,38 @@
-# State Escalation (TODO)
+# State Escalation
 
----
+Using the `parse_version` example seen earlier in our documentation, we can see
+that the `Version` enum can return either `V1` or `V2`. At some point, a tool
+parsing some version number might choose to deprecate support for `V1`. In
+these instances, a developer might choose to turn `V1` into a `Mistake`.
+However, `parse_version` returns a `Success(V1)`. How, then, can we turn this
+into a `Mistake` *in-place*?
+
+This is where *state escalation* comes into play. It is one of the more
+experimental features that `outcome` is trying to experiment with. The basic
+idea of this concept is a successful outcome for *one function* does not imply
+that the caller considers the successful value valid enough to continue.
+
+With state escalation, we not only *move* the possible state of an `Outcome`
+from `Success` to `Mistake` or `Mistake` to `Failure`, but we are also able to
+eliminate possible states from the `Outcome`. That is, given an `Outcome<S, M,
+F>`, the first state escalation would return an `Outcome<!, M, F>` (on
+stable, this returns an `Outcome<Infallible, M, F>`. A second state
+escalation would result in an `Outcome<!, !, F>`. This allows for *fast* state
+transitions with little to no effort, while keeping this state transition
+separate from mapping operations. The benefit of reducing the possible set of
+states that the `Outcome` can represent is simply a *side effect* of Rust's
+powerful type system with regards to `enum`s and their variants.
+
+It is important to note that there is no *de-escalation* of state possible
+without explicit operations from users. In other words, a new Outcome must be
+generated when one or more fields are `Infallible`. This is difficult to
+enforce without certain features missing from Rust, specifically partial
+specialization and `impl` overloading (e.g., an `Outcome<!, M, F>` should *not*
+be allowed to have `and_then` called on it). However this same limitation is
+found in `Result` and other variants, and even Finite State Machines
+implemented with Rust `enum`s will suffer the same fate. In an ideal world,
+Outcome's state escalation would only permit unidirectional transitions, and
+would require the creation of a completely *new* `Outcome` if a user wanted to
+reset or *de-escalate* the `Outcome`. This might not ever be possible to do or
+enforce in Rust, so in the meantime it is up to users to behave themselves with
+regards to escalating state.

--- a/src/nightly.rs
+++ b/src/nightly.rs
@@ -14,6 +14,49 @@ use std::{
 use crate::prelude::*;
 
 /* feature(never_type) */
+impl<S, M, F> Outcome<S, M, F> {
+  /// **`TODO`**: write documentation
+  pub fn escalate_with<C, T>(self, closure: C) -> Outcome<!, M, F>
+  where
+    T: Into<M>,
+    C: FnOnce(S) -> T,
+  {
+    match self {
+      Success(s) => Mistake(closure(s).into()),
+      Mistake(m) => Mistake(m),
+      Failure(f) => Failure(f),
+    }
+  }
+}
+
+impl<S: Into<!>, M: Into<F>, F> Outcome<S, M, F> {
+  /// Escalates an [`Outcome`] from a [`Mistake`] to a [`Failure`]
+  pub fn escalate_mistake(self) -> Outcome<!, !, F> {
+    match self {
+      Success(s) => s.into(),
+      Mistake(m) => Failure(m.into()),
+      Failure(f) => Failure(f),
+    }
+  }
+}
+
+impl<S: Into<!>, M, F> Outcome<S, M, F> {
+  /// Escalates an [`Outcome`] from a [`Mistake`] to a [`Failure`] using the
+  /// given closure.
+  ///
+  pub fn escalate_mistake_with<C, G>(self, closure: C) -> Outcome<!, !, F>
+  where
+    G: Into<F>,
+    C: FnOnce(M) -> G,
+  {
+    match self {
+      Success(s) => s.into(),
+      Mistake(m) => Failure(closure(m).into()),
+      Failure(f) => Failure(f),
+    }
+  }
+}
+
 impl<S, M: Into<!>, F: Into<!>> Outcome<S, M, F> {
   /// Returns the contained [`Success`] value, but never panics.
   ///

--- a/src/outcome.rs
+++ b/src/outcome.rs
@@ -587,6 +587,7 @@ impl<S: DerefMut, M, F> Outcome<S, M, F> {
 
 #[cfg(not(feature = "nightly"))]
 impl<S, M, F> Outcome<S, M, F> {
+  /// **`TODO`**: Write documentation
   pub fn escalate_with<C, T>(self, closure: C) -> Aberration<M, F>
   where
     T: Into<M>,


### PR DESCRIPTION
✨ Add initial set of state escalation calls 🐛 Fix missing docs when creating a crate  It should be noted that as of right now, we need to worry about the situation where a user might not remember to enable all features for a given feature. For this reason we'll need to, at some point, refactor the nightly module and create a few more subfeatures. This will break up the `nightly` feature a bit more, but on the bright side the `nightly` feature becomes an umbrella feature.  Lastly, despite these initial docs regarding state escalation we don't have examples in place (nor tests!) to support our interfaces. This will be rectified with later PRs, most likely after the nightly feature refactor.    